### PR TITLE
WIP: Javascript support redux

### DIFF
--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -26,7 +26,7 @@ class Source(Base):
         self.debug_enabled = True
         self.name = "typescript"
         self.mark = "TS"
-        self.filetypes = ["typescript", "tsx", "typescript.tsx"]
+        self.filetypes = ["typescript", "tsx", "typescript.tsx", "javascript", "jsx", "javascript.jsx"] if vim.vars["nvim_typescript#javascript_support"] else ["typescript", "tsx", "typescript.tsx"]
         self.rank = 1000
         self.input_pattern = r"\.\w*"
         self._last_input_reload = time()

--- a/rplugin/python3/nvim-typescript/__init__.py
+++ b/rplugin/python3/nvim-typescript/__init__.py
@@ -238,6 +238,7 @@ class TypescriptHost():
                 self._client.start()
                 self.server = True
                 self.vim.out_write('TS: Server Started \n')
+                self._client.setDefaultCompileOptions()
                 self._client.open(self.relative_file())
             else:
                 self._client.open(self.relative_file())

--- a/rplugin/python3/nvim-typescript/__init__.py
+++ b/rplugin/python3/nvim-typescript/__init__.py
@@ -53,6 +53,13 @@ class TypescriptHost():
         self.settings = ['setl modifiable', 'setl noswapfile',
                          'setl buftype=nofile', 'setl nomodifiable', 'setl nomodified']
 
+    def is_valid(self, filename):
+        """
+            Return whether or not the current file is valid for commands
+        """
+        # pylint: disable=locally-disabled, line-too-long
+        return filename.endswith((".ts", ".tsx")) or self.vim.vars["nvim_typescript#javascript_support"]
+
     def relative_file(self):
         """
             Return the current file
@@ -213,24 +220,32 @@ class TypescriptHost():
                 'echohl WarningMsg | echo "TS: Server is not Running" | echohl None')
 
     # Various Auto Commands
+    @neovim.autocmd('CursorHold', pattern='*.ts,*.tsx,*.js,*.jsx')
+    def on_cursorhold(self):
+        """
+        get type info on cursor hold
+        """
+        self.vim.command('TSType')
 
-    @neovim.autocmd('BufEnter', pattern='*.ts,*.tsx')
+    @neovim.autocmd('BufEnter', pattern='*.ts,*.tsx,*.js,*.jsx')
     def on_bufenter(self):
         """
            Send open event when a ts file is open
 
         """
-        if self.server is None:
-            self._client.start()
-            self.server = True
-            self.vim.out_write('TS: Server Started \n')
-            self._client.open(self.relative_file())
-        else:
-            self._client.open(self.relative_file())
+        if self.is_valid(self.relative_file()):
+            if self.server is None:
+                self._client.start()
+                self.server = True
+                self.vim.out_write('TS: Server Started \n')
+                self._client.open(self.relative_file())
+            else:
+                self._client.open(self.relative_file())
 
-    @neovim.autocmd('BufWritePost', pattern='*.ts,*.tsx')
+    @neovim.autocmd('BufWritePost', pattern='*.ts,*.tsx,*.js,*.jsx')
     def on_bufwritepost(self):
         """
            On save, reload to detect changes
         """
-        self.reload()
+        if self.is_valid(self.relative_file()):
+            self.reload()

--- a/rplugin/python3/nvim-typescript/client.py
+++ b/rplugin/python3/nvim-typescript/client.py
@@ -42,7 +42,7 @@ class Client:
             return
 
         Client.__server_handle = subprocess.Popen(
-            "tsserver",
+            "tsserver --useSingleInferredProject",
             env=Client.__environ,
             cwd=Client.__project_directory,
             stdout=subprocess.PIPE,
@@ -112,7 +112,7 @@ class Client:
             headerline = Client.__server_handle.stdout.readline().strip()
             linecount += 1
 
-            if len(headerline):
+            if len(headerline) and ":" in headerline:
                 key, value = headerline.split(":", 2)
                 headers[key.strip()] = value.strip()
 
@@ -224,6 +224,22 @@ class Client:
                 'findInComments': True, 'findInStrings': True}
         response = self.send_request("rename", args, True)
         return response
+
+    def setDefaultCompileOptions(self):
+        """
+            Sends a "compilerOptionsForInferredProjects" request
+        """
+        args = {
+            "compilerOptions": {
+                "target": "es2017",
+                "module": "es6",
+                "jsx": "preserve",
+                "allowSyntheticDefaultImports": "true",
+                "allowNonTsExtensions": "true",
+                "allowJs": "true",
+            }
+        }
+        self.send_request("compilerOptionsForInferredProjects", args)
 
     def completions(self, file, line, offset, prefix=""):
         """


### PR DESCRIPTION
Fixes #32 

Opening this for feedback

1. Checking the filetype on the autocmds seems super hacky, but for now was the only way I could see to both allow those to fire on javascript but also stop them from firing when javascript support isn't enabled. I'm open to other options or feedback here

2. The default compile options are super arbitrary here and open for discussion. I _really_ like this for my javascript projects but it's probably not the best set of defaults

3. I'm not seeing a nice way to allow the user to set their own default compile options. Ideally they would set these in their vimrc, but I don't know how one would do that since this is sent to the server as a fairly complex JSON object. I could see reading from a file in the user's XDG or home directories, but that seems non-ideal. Open for ideas here

After some of these details are ironed out, I'll add docs for all of this and clean up some of my code here so it's ready to be merged