### PR TITLE
feat(): jsSupport 

### DIFF
--- a/plugin/nvim-typescript.vim
+++ b/plugin/nvim-typescript.vim
@@ -13,10 +13,24 @@ let g:nvim_typescript#signature_complete =
 
 augroup nvim-typescript
   autocmd!
+
   if get(g:, 'nvim_typescript#type_info_on_hold', 1)
+    if get(g:, 'nvim_typescript#javascript_support', 1)
+       autocmd CursorHold *.ts,*.tsx,*.js,*.jsx TSType
+    endif
      autocmd CursorHold *.ts,*.tsx TSType
   endif
+
   if get(g:, 'nvim_typescript#signature_complete', 1)
      autocmd CompleteDone *.ts,*.tsx TSSig
   endif
+
+  if get(g:, 'nvim_typescript#javascript_support', 1)
+    autocmd BufEnter *.ts,*.tsx,*.js,*.jsx call NvimTSEnter()
+    autocmd BufWritePost *.ts,*.tsx,*.js,*.jsx call NvimTsSave()
+  else
+    autocmd BufEnter *.ts,*.tsx call NvimTSEnter()
+    autocmd BufWritePost *.ts,*.tsx call NvimTsSave()
+  endif
+
 augroup end

--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -26,12 +26,14 @@ class Source(Base):
         self.debug_enabled = True
         self.name = "typescript"
         self.mark = "TS"
-        self.filetypes = ["typescript", "tsx", "typescript.tsx"]
+        self.filetypes = ["typescript", "tsx", "typescript.tsx", "javascript", "jsx", "javascript.jsx"] if self.vim.vars[
+            "nvim_typescript#javascript_support"] else ["typescript", "tsx", "typescript.tsx"]
         self.rank = 1000
         self.input_pattern = r"\.\w*"
         self._last_input_reload = time()
-        self._max_completion_detail = vim.eval(
-            "nvim_typescript#max_completion_detail")
+        # pylint: disable=locally-disabled, line-too-long
+        self._max_completion_detail = self.vim.eval(
+            "g:nvim_typescript#max_completion_detail")
 
         # TSServer client
         self._client = Client(debug_fn=self.debug, log_fn=self.log)
@@ -132,7 +134,8 @@ class Source(Base):
 
         # needed to strip new lines and indentation from the signature
         signature = re.sub("\s+", " ", signature)
-        menu_text = re.sub("^(var|let|const|class|\(method\)|\(property\)|enum|namespace|function|import|interface|type)\s+", "", signature)
+        menu_text = re.sub(
+            "^(var|let|const|class|\(method\)|\(property\)|enum|namespace|function|import|interface|type)\s+", "", signature)
         documentation = menu_text
 
         if "documentation" in entry and entry["documentation"]:

--- a/rplugin/python3/nvim-typescript/__init__.py
+++ b/rplugin/python3/nvim-typescript/__init__.py
@@ -105,14 +105,18 @@ class TypescriptHost():
     def writeFile(self):
         jsSupport = self.vim.eval('g:nvim_typescript#javascript_support')
         if bool(jsSupport):
-            with open('jsconfig.json', 'w') as config:
-                json.dump(defaultArgs, config, indent=2,
-                          separators=(',', ': '))
-                config.close()
-                self.vim.command('redraws')
-                self.vim.out_write(
-                    'nvim-ts: js support was enable, but no config is present, writting defualt jsconfig.json \n')
-                self.tsstart()
+            input = self.vim.call('input', 'nvim-ts: config is not present, create one? ')
+            if input == "yes":
+                with open('jsconfig.json', 'w') as config:
+                    json.dump(defaultArgs, config, indent=2,
+                              separators=(',', ': '))
+                    config.close()
+                    self.vim.command('redraws')
+                    self.vim.out_write(
+                        'nvim-ts: js support was enable, but no config is present, writting defualt jsconfig.json \n')
+                    self.tsstart()
+            else:
+                self.vim.out_write('TSServer not started.')
 
     @neovim.command("TSStop")
     def tsstop(self):

--- a/rplugin/python3/nvim-typescript/dir.py
+++ b/rplugin/python3/nvim-typescript/dir.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import logging
+sys.path.insert(1, os.path.dirname(__file__) + '/globster')
+from globster import Globster
+log = logging.getLogger("nvim-dir")
+
+class Dir(object):
+
+    def __init__(self, directory=".", excludes=['.git/', '.hg/', '.svn/', 'node_modules']):
+
+        self.directory = os.path.basename(directory)
+        self.path = os.path.abspath(directory)
+        self.parent = os.path.dirname(self.path)
+        self.exclude_file = self.load_ignore()
+        self.patterns = excludes
+        if self.exclude_file is not None:
+            self.patterns.extend(self.load_patterns(self.exclude_file))
+        self.globster = Globster(self.patterns)
+
+
+    def load_ignore(self):
+        if os.path.isfile(os.path.join(self.path, '.gitignore')):
+            return os.path.join(self.path, '.gitignore')
+        else:
+            return None
+
+    def load_patterns(self, exclude_file):
+        res = []
+        ignore = filter(None, open(exclude_file).read().split("\n"))
+        for val in ignore:
+            if val.startswith('#'):
+                pass
+            else:
+                res.append(val)
+        return res
+
+    def iterfiles(self):
+        for root, dirs, files in self.walk():
+            for f in files:
+                yield self.relpath(os.path.join(root, f))
+
+    def files(self):
+        return sorted(self.iterfiles())
+
+    def is_excluded(self, path):
+        match = self.globster.match(self.relpath(path))
+        if (match):
+            return True
+        return False
+
+    def walk(self):
+        for root, dirs, files in os.walk(self.path, topdown=True):
+            ndirs = []
+            # First we exclude directories
+            for d in list(dirs):
+                if self.is_excluded(os.path.join(root, d)):
+                    dirs.remove(d)
+                elif not os.path.islink(os.path.join(root, d) + '/'):
+                    ndirs.append(d)
+
+            nfiles = []
+            for fpath in (os.path.join(root, f) for f in files):
+                if not self.is_excluded(fpath):
+                    nfiles.append(os.path.relpath(fpath, root))
+            yield root, ndirs, nfiles
+
+    def relpath(self, path):
+        return os.path.relpath(path, start=self.path)


### PR DESCRIPTION
This is derived from the work that @DonnieWest has done in #39 but goes in a different direction.

Basically, I moved some of the auto-logic here to vim side (for some better control of things)
But, if a person has js support enabled, instead of sending default arguments to TSServer, just write out a jsconfig.json instead. A bit more long-lasting imo. 

I have js-support turned off for now, until I make a doc file.

@DonnieWest opinions?