### PR TITLE
feat(): Use location list instead of quickfix list

### DIFF
--- a/rplugin/python3/nvim-typescript/__init__.py
+++ b/rplugin/python3/nvim-typescript/__init__.py
@@ -259,8 +259,8 @@ class TypescriptHost(object):
                             'col': error['start']['offset'],
                             'text': error['text']
                         })
-                    self.vim.call('setqflist', errorLoc, 'r', 'Errors')
-                    self.vim.command('cwindow')
+                    self.vim.call('setloclist', 0, errorLoc, 'r', 'Errors')
+                    self.vim.command('lwindow')
         else:
             self.printError('Server is not Running')
 


### PR DESCRIPTION
Create an option - `g:nvim_typescript#use_location_list` - that, when set to `1`, puts the errors from `TSGetErr` in the location list instead of the quickfix list.

I'm not all that comfortable writing Vim plugins, but this worked locally. Not sure if the check should be somewhere else in the code as well?

Edit: Also, not sure if `0` should be used for the window number? It's what is used in Neomake and, like I said, it worked for me, but there might be a better option?