### PR TITLE
User customizable location list item length

### DIFF
--- a/doc/nvim-typescript.txt
+++ b/doc/nvim-typescript.txt
@@ -167,6 +167,15 @@ g:nvim_typescript#ts_version
     The current version typescript that is supported by this plugin. Version
     past this may include breaking changes.
 
+
+                               *g:nvim_typescript#loc_list_item_truncate_after*
+g:nvim_typescript#loc_list_item_truncate_after
+Values: Any positive natural number or -1
+Default: 20
+
+    Defines the length of items displayed in the location window after a call
+    to |:TSRefs|.
+
 ===============================================================================
 MAPPINGS                                                  *typescript-mappings*
 

--- a/plugin/nvim_typescript.vim
+++ b/plugin/nvim_typescript.vim
@@ -16,6 +16,9 @@ let g:nvim_typescript#type_info_on_hold =
 let g:nvim_typescript#signature_complete =
       \ get(g:, 'nvim_typescript#signature_complete', 0)
 
+let g:nvim_typescript#loc_list_item_truncate_after =
+      \ get(g:, 'nvim_typescript#loc_list_item_truncate_after', 20)
+
 
 let s:kind_symbols = {
     \ 'keyword': 'keyword',

--- a/rplugin/python3/nvim-typescript/__init__.py
+++ b/rplugin/python3/nvim-typescript/__init__.py
@@ -390,15 +390,21 @@ class TypescriptHost(object):
             if (not refs) or (refs['success'] is False):
                 pass
             else:
+                truncateAfter = self.vim.eval('g:nvim_typescript#loc_list_item_truncate_after')
                 location_list = []
                 refList = refs["body"]["refs"]
                 if len(refList) > -1:
                     for ref in refList:
+                        lineText = re.sub('^\s+', '', ref['lineText'])
+                        if (truncateAfter == -1) or (len(lineText) <= truncateAfter):
+                            lineText
+                        else :
+                            lineText = (lineText[:truncateAfter] + '...')
                         location_list.append({
                             'filename': re.sub(self.cwd + '/', '', ref['file']),
                             'lnum': ref['start']['line'],
                             'col': ref['start']['offset'],
-                            'text': (ref['lineText'][:20] + '...') if len(ref['lineText']) > 20 else ref['lineText']
+                            'text': lineText
                         })
                     self.vim.call('setloclist', 0, location_list,
                                   'r', 'References')


### PR DESCRIPTION
Added `g:nvim_typescript#loc_list_item_truncate_after` to allow the user
to customize the length of location list items after a call to
`:TSRefs`, while not taking into account leading spaces.

Updated docs.