### PR TITLE
Limit `navTo` results to 100.

### DIFF
--- a/rplugin/python3/nvim-typescript/client.py
+++ b/rplugin/python3/nvim-typescript/client.py
@@ -211,8 +211,8 @@ class Client(object):
         response = self.send_request("navtree", args)
         return response
 
-    def getWorkplaceSymbols(self, file, term=None):
-        args = {"file": file, "searchValue": term}
+    def getWorkspaceSymbols(self, file, term=None):
+        args = {"file": file, "searchValue": term, "maxResultCount": 100}
         response = self.send_request("navto", args)
         return response
 


### PR DESCRIPTION
Currently the python plugin process communicates with tsserver using
subprocess.Popen and subprocess.PIPE to interact with tsserver via
stdin and stdout.

As discussed [here](https://github.com/mhartington/nvim-typescript/pull/55) and
[here](https://thraxil.org/users/anders/posts/2008/03/13/Subprocess-Hanging-PIPE-is-your-enemy/)
this can potentially silently deadlock the python process.

Limiting the search results to 100 (a reasonable but admittedly
arbitrary limit) for the `navTo` command should help with limiting the chances
of that happening.