### PR TITLE
bug(health): Fixed boolean test if TSFindConfig

### DIFF
--- a/rplugin/python3/nvim-typescript/__init__.py
+++ b/rplugin/python3/nvim-typescript/__init__.py
@@ -72,7 +72,7 @@ class TypescriptHost(object):
 
     @neovim.function("TSFindConfig", sync=True)
     def findconfig(self, args=None):
-        return self._client.project_root
+        return self._client.project_root is not None
 
     def writeFile(self):
         jsSupport = self.vim.eval('g:nvim_typescript#javascript_support')


### PR DESCRIPTION
The vimL part of the code was interpreting `None` as a truthy value, I
guess this is a bug in the python neovim client, we should notify them
if that's the case.

Fixes #66.