### PR TITLE
Add compatibility with Python 3.4

### DIFF
--- a/rplugin/python3/nvim-typescript/utils.py
+++ b/rplugin/python3/nvim-typescript/utils.py
@@ -21,7 +21,7 @@ def getImportCandidates(client, currentFile, symbol):
             x['name'] == symbol  # tsserver `exact` matchKind is not case sensitive
 
     filtered = filter(filterSymbols, matchingSymbols)
-    files = [*map(lambda x: x["file"], filtered)]
+    files = list(map(lambda x: x["file"], filtered))
     return files
 
 def getRelativeImportPath(destinationFile, importFromFile):
@@ -81,13 +81,13 @@ def getCurrentImports(client, inspectedFile):
     imports = [x for x in client.getDocumentSymbols(inspectedFile)["childItems"]
                if x["kind"] == "alias"]
 
-    importLineLocations = sorted([*map(lambda x: x["spans"][0]["end"]["line"], imports)])
+    importLineLocations = sorted(list(map(lambda x: x["spans"][0]["end"]["line"], imports)))
     lastImportLine = 0
 
     if len(importLineLocations) > 0:
         lastImportLine = importLineLocations[-1]
 
-    return ([*map(lambda x: x["text"], imports)], lastImportLine)
+    return list(map(lambda x: x["text"], imports), lastImportLine)
 
 def _shaveNodeModulesPath(candidate):
     return re.sub(r'^.*node_modules/([^/]+)(?:/.*$)?', r'\1', candidate)


### PR DESCRIPTION
With this small change it is possible to run this plugin with Python version 3.4, which ships with a few distros e.g. opensuse leap, debian jessie.

Basically it replaces non-backward compatible syntax introduced in Python 3.5 ([PEP-0448](https://www.python.org/dev/peps/pep-0448/)) with a simple `list()` constructor. 

Here's the error output without this patch:

![zrzut ekranu z 2017-09-02 21-00-47](https://user-images.githubusercontent.com/142805/29998085-3e408394-9022-11e7-819e-84cc313efbfe.png)
