### PR TITLE
More robust tsc version detection

### DIFF
--- a/rplugin/python3/nvim-typescript/client.py
+++ b/rplugin/python3/nvim-typescript/client.py
@@ -50,7 +50,7 @@ class Client(object):
         rawOutput = subprocess.check_output(['tsc', '--version'])
         # formats out to be a list [major, minor, patch]
         [major, minor, patch] = rawOutput.rstrip().decode(
-            "utf-8").replace('Version ', '').split('.')
+                "utf-8").split(' ').pop().split('.')
         self.tsConfg = {"major": int(major), "minor": int(
             minor), "patch": int(patch)}
 


### PR DESCRIPTION
I was getting the following error:
```
error caught in async handler '/Users/artbit/.config/nvim/plugged/nvim-typescript/rplugin/python3/nvim-typescript:function:TSOnBufEnter [[]]'
Traceback (most recent call last):
  File "/Users/artbit/.config/nvim/plugged/nvim-typescript/rplugin/python3/nvim-typescript/__init__.py", line 609, in on_bufenter
    self.tsstart()
  File "/Users/artbit/.config/nvim/plugged/nvim-typescript/rplugin/python3/nvim-typescript/__init__.py", line 72, in tsstart
    self._client.setTsConfig()
  File "/Users/artbit/.config/nvim/plugged/nvim-typescript/rplugin/python3/nvim-typescript/client.py", line 54, in setTsConfig
    self.tsConfg = {"major": int(major), "minor": int(
ValueError: invalid literal for int() with base 10: 'message TS6029: 1'
```

Which was caused by `tsc` version string not being in the format that the plugin expects.
It looks like the code expects the version format to be in the form of `Version 1.2.3.4` while I get the following instead:
```
$ tsc --version
message TS6029: Version 1.4.1.0
```

So instead of just trying to strip the `Version ` from the version string, let's just split the string on spaces and pop the last part.