### PR TITLE
Fix/tsimport sometimes applies import fix incorrectly

### DIFF
--- a/rplugin/python3/nvim_typescript/__init__.py
+++ b/rplugin/python3/nvim_typescript/__init__.py
@@ -418,10 +418,18 @@ class TypescriptHost(object):
                     elif addingNewLine:
                         self.vim.current.buffer.append(newText, changeLine + 1)
                     else:
+                        addingTrailingComma = re.match(r'^,$', newText) is not None
                         lineToChange = self.vim.current.buffer[changeLine]
-                        modifiedLine = lineToChange[
-                            :changeOffset - 1] + newText + lineToChange[changeOffset - 1:]
-                        self.vim.current.buffer[changeLine] = modifiedLine
+                        lineAlreadyHasTrailingComma = re.match(r'^.*,\s*$', lineToChange) is not None
+
+                        # we have to do this check because TSServer doesn't take into account if we already
+                        # have a trailing comma before suggesting one
+                        if addingTrailingComma and lineAlreadyHasTrailingComma:
+                            pass
+                        else:
+                            modifiedLine = lineToChange[
+                                :changeOffset - 1] + newText + lineToChange[changeOffset - 1:]
+                            self.vim.current.buffer[changeLine] = modifiedLine
 
 
     # REQUEST NAVTREE/DOC SYMBOLS

--- a/rplugin/python3/nvim_typescript/__init__.py
+++ b/rplugin/python3/nvim_typescript/__init__.py
@@ -410,9 +410,13 @@ class TypescriptHost(object):
                 for change in textChanges:
                     changeLine = change['start']['line'] - 1
                     changeOffset = change['start']['offset']
-                    newText = change['newText'].strip()
+                    leadingNewLineRegex = r'^\n'
+                    addingNewLine= re.match(leadingNewLineRegex, change['newText']) is not None
+                    newText = re.sub(leadingNewLineRegex, '', change['newText'])
                     if changeOffset == 1:
                         self.vim.current.buffer.append(newText, changeLine)
+                    elif addingNewLine:
+                        self.vim.current.buffer.append(newText, changeLine + 1)
                     else:
                         lineToChange = self.vim.current.buffer[changeLine]
                         modifiedLine = lineToChange[


### PR DESCRIPTION
when auto importing into a group of imports that looks like this:
```
import {
  uniq,
  map,
} from 'lodash';
```

auto importing the `filter` function from lodash would end up doing this:
```
import {
  uniq,
  mapfilter,,
} from 'lodash';
```
due to it not handling the presence of trailing commas in the existing statement and not taking into account the '\n' in the fix suggestion from TSServer. 

This PR resolves both of these issues and now makes the suggested fixes from TSServer correctly: 
```
import {
  uniq,
  map,
  filter
} from 'lodash';
```