### PR TITLE
support nightly typescript

### DIFF
--- a/rplugin/python3/nvim_typescript/client.py
+++ b/rplugin/python3/nvim_typescript/client.py
@@ -51,8 +51,10 @@ class Client(object):
         command = self.serverPath.replace('tsserver', 'tsc')
         rawOutput = subprocess.check_output(
             [command + ' --version'], shell=True)
-        [major, minor, patch] = rawOutput.rstrip().decode(
-            "utf-8").split(' ').pop().split('.')
+        # strip nightly
+        pure_version = rawOutput.rstrip().decode(
+                'utf-8').split(' ').pop().split('-')[0]
+        [major, minor, patch] = pure_version.split('.')[:3]
         self.tsConfg = {"major": int(major), "minor": int(
             minor), "patch": int(patch)}
 


### PR DESCRIPTION
I found nvim-typescript doesn't support nightly, of which the version string is `Version 2.7.0-dev.20180116`

We can simply ignore string after `-`