### PR TITLE
fix(TSImport): trim newlines from end of import statement

### DIFF
--- a/rplugin/python3/nvim_typescript/__init__.py
+++ b/rplugin/python3/nvim_typescript/__init__.py
@@ -425,7 +425,11 @@ class TypescriptHost(object):
                 leadingNewLineRegex = r'^\n'
                 addingNewLine = re.match(leadingNewLineRegex, change[
                                          'newText']) is not None
-                newText = re.sub(leadingNewLineRegex,
+
+                leadingAndTrailingNewLineRegex = r'^\n|\n$'
+                addingNewLine= re.match(leadingNewLineRegex, change[
+                                        'newText']) is not None
+                newText = re.sub(leadingAndTrailingNewLineRegex,
                                  '', change['newText'])
                 if changeOffset == 1:
                     self.vim.current.buffer.append(newText, changeLine)


### PR DESCRIPTION
text with newlines cant be added to the buffer through the python -> vim
interface.