### PR TITLE
TSRename: Replaced change operation with substitution

### DIFF
--- a/rplugin/python3/nvim_typescript/__init__.py
+++ b/rplugin/python3/nvim_typescript/__init__.py
@@ -298,7 +298,7 @@ class TypescriptHost(object):
                 for rename in loc['locs']:
                     line = rename['start']['line']
                     col = rename['start']['offset']
-                    substitutions.append('{}s/\%{}c{}/{}/'.format(line, col, symbol, newName))
+                    substitutions.append('{}substitute/\%{}c{}/{}/'.format(line, col, symbol, newName))
                     changeCount += 1
                 self.vim.command(' | '.join(substitutions))
             self.vim.funcs.cursor(originalLine, offset)


### PR DESCRIPTION
TSRename currently only works, if `c` or `w` haven't been mapped to something else. I replaced the `cw`-approach with `substitute`. This should make it more compatible with customized key bindings. It might even fix #124.

While working on this I noticed, that it only works on the current buffer. I checked the file history and it appears, that the project-wide-replacement functionality was removed at some point. Is there any particular reason for this?