### PR TITLE
fix(install): Specify shell for install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 cd rplugin/node/nvim_typescript && npm install && npm run build


### PR DESCRIPTION
Without specifying a shell upfront, the install script is being executed with the default shell of the user. Some shells don't support command concatenation via `&&` (e.g. [fish](https://fishshell.com/)) and will fail while executing the script. This PRs ensures, that it is always executed with `sh`, which should be available on every Unix/Linux based system.