### PR TITLE
misc(): Do not re-open current file.

### DIFF
--- a/rplugin/node/nvim_typescript/lib/index.js
+++ b/rplugin/node/nvim_typescript/lib/index.js
@@ -464,12 +464,17 @@ let TSHost = class TSHost {
     }
     openBufferOrWindow(file, lineNumber, offset) {
         return __awaiter(this, void 0, void 0, function* () {
+            const fileIsAlreadyFocused = yield this.getCurrentFile().then(currentFile => file === currentFile);
+            if (fileIsAlreadyFocused) {
+                yield this.nvim.command(`call cursor(${lineNumber}, ${offset})`);
+                return;
+            }
             const windowNumber = yield this.nvim.call('bufwinnr', file);
             if (windowNumber != -1) {
                 yield this.nvim.command(`${windowNumber}wincmd w`);
             }
             else {
-                yield this.nvim.command(`e! ${file}`);
+                yield this.nvim.command(`e ${file}`);
             }
             yield this.nvim.command(`call cursor(${lineNumber}, ${offset})`);
         });

--- a/rplugin/node/nvim_typescript/src/index.ts
+++ b/rplugin/node/nvim_typescript/src/index.ts
@@ -503,11 +503,20 @@ export default class TSHost {
   }
 
   async openBufferOrWindow(file: string, lineNumber: number, offset: number) {
+
+    const fileIsAlreadyFocused =
+        await this.getCurrentFile().then(currentFile => file === currentFile);
+
+    if (fileIsAlreadyFocused) {
+        await this.nvim.command(`call cursor(${lineNumber}, ${offset})`);
+        return;
+    }
+
     const windowNumber = await this.nvim.call('bufwinnr', file);
     if (windowNumber != -1) {
       await this.nvim.command(`${windowNumber}wincmd w`);
     } else {
-      await this.nvim.command(`e! ${file}`);
+      await this.nvim.command(`e ${file}`);
     }
     await this.nvim.command(`call cursor(${lineNumber}, ${offset})`);
   }


### PR DESCRIPTION
This was unneeded and slowed things down a bit (for nothing).