### PR TITLE
Fix documentation for dein

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Then add the following plugins. This example uses Dein.vim, but any plugin manag
 
 ```viml
  " Dein
-  call dein#add('mhartington/nvim-typescript', {'build': './install'}
+  call dein#add('mhartington/nvim-typescript', {'build': './install.sh'})
  " For async completion
-   call dein#add('Shougo/deoplete.nvim')
+  call dein#add('Shougo/deoplete.nvim')
 
 
  " Plug


### PR DESCRIPTION
In addition to the missing closing parenthesis, I was thinking that `dein` was clever enough to not need the `.sh` extension for the install script and spent quite some time pulling my hairs, not understanding why the plugin wouldn't work. Turns out you *do* need the `.sh` extension :P