### PR TITLE
Use TSDeoplete method for async completions

### DIFF
--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -37,7 +37,7 @@ class Source(Base):
     def gather_candidates(self, context):
         try:
             [offset] = context["complete_position"] + 1,
-            self.vim.funcs.TSComplete(context["complete_str"], offset)
+            self.vim.funcs.TSDeoplete(context["complete_str"], offset)
             res = self.vim.vars["nvim_typescript#completionRes"]
             if len(res) == 0:
                 return []


### PR DESCRIPTION
Hi @mhartington - thanks a bunch for all the work you put into this!

I upgraded recently, and found that some of the autocompletions were causing blocking in my nvim. This change fixed it for me, but LMK if there's a reason why the python source is not calling into the TSDeoplete method.