### PR TITLE
Add ncm2 source

### DIFF
--- a/autoload/ncm2/nvim_typescript.vim
+++ b/autoload/ncm2/nvim_typescript.vim
@@ -1,0 +1,23 @@
+
+func! ncm2#nvim_typescript#init()
+    let scope = ['typescript', 'tsx', 'typescript.tsx']
+    if g:nvim_typescript#javascript_support
+        call extend(scope, ['javascript', 'jsx', 'javascript.jsx'])
+      endif
+    if g:nvim_typescript#vue_support
+        call insert(scope, 'vue')
+    endif
+    " the omnifunc pattern is PCRE
+    call ncm2#register_source({'name' : 'typescript',
+            \ 'priority': 9,
+            \ 'scope': scope,
+            \ 'mark': g:nvim_typescript#completion_mark,
+            \ 'complete_pattern':['\.', '::'],
+            \ 'on_complete': 'ncm2#nvim_typescript#on_complete',
+            \ })
+endfunc
+
+func! ncm2#nvim_typescript#on_complete(ctx)
+    call TSNcm2OnComplete(a:ctx)
+endfunc
+

--- a/ncm2-plugin/nvim_typescript.vim
+++ b/ncm2-plugin/nvim_typescript.vim
@@ -1,0 +1,4 @@
+" ncm2 source
+
+call ncm2#nvim_typescript#init()
+


### PR DESCRIPTION
as per ncm2/ncm2#33

minimal test vimrc:

```vim
execute 'source ' . $WORKSPACE_DIR . '/plug.vim'

call plug#begin($WORKSPACE_DIR)

Plug 'ncm2/ncm2'
Plug 'roxma/nvim-yarp'
Plug 'HerringtonDarkholme/yats.vim'
Plug 'ncm2/nvim-typescript', {'do': './install.sh'}

call plug#end()

autocmd BufEnter * call ncm2#enable_for_buffer()
set completeopt=noinsert,menuone,noselect
```

Demo:

![peek 2018-07-18 10-17](https://user-images.githubusercontent.com/4538941/42855637-05d66972-8a74-11e8-8304-a6233f56b1eb.gif)

It should be possible to add snippet support, based on [ncm2-ultisnips](http://github.com/ncm2/ncm2-ultisnips). Don't have the time to finish that part. My typescript skill is still on `Hello world` level.

@isczg Please test this PR.