### PR TITLE
diagnostics placed into location list

### DIFF
--- a/rplugin/node/nvim_typescript/lib/diagnostic.js
+++ b/rplugin/node/nvim_typescript/lib/diagnostic.js
@@ -43,7 +43,7 @@ class DiagnosticProvider {
                 });
             }));
             yield this.highlightLine(current.file);
-            utils_1.createQuickFixList(this.nvim, locList, 'Errors', false);
+            utils_1.createLocList(this.nvim, locList, 'Errors', false);
         });
     }
     normalizeSigns(signs) {

--- a/rplugin/node/nvim_typescript/src/diagnostic.ts
+++ b/rplugin/node/nvim_typescript/src/diagnostic.ts
@@ -42,8 +42,9 @@ export class DiagnosticProvider {
       });
     })
     await this.highlightLine(current.file);
-    createQuickFixList(this.nvim, locList, 'Errors', false);
+    createLocList(this.nvim, locList, 'Errors', false);
   }
+
   normalizeSigns(signs: Diagnostic[]) {
     return signs.map(sign => {
       return { ...sign, id: this.signID++ };


### PR DESCRIPTION
Since diagnostics come from the current buffer, it makes sense to put them into the location list for that buffer.

This works better with plugins that use the quickfix list for global navigation, like https://github.com/BurntSushi/ripgrep

currently, you can't jump through a list of matching locations since it gets overwritten as soon as TSGetDiagnostics run