### PR TITLE
Resolve issues with Windows

### DIFF
--- a/plugin/nvim_typescript.vim
+++ b/plugin/nvim_typescript.vim
@@ -180,5 +180,8 @@ augroup nvim-typescript "{{{
   autocmd BufWritePost tsconfig.json TSReloadProject
   autocmd User CmSetup call cm#sources#typescript#register()
 
+  " Cleanup required to prevent hanging on Windows exit
+  autocmd VimLeavePre * TSStop 
+
 augroup end "}}}
 

--- a/rplugin/node/nvim_typescript/lib/client.js
+++ b/rplugin/node/nvim_typescript/lib/client.js
@@ -33,13 +33,26 @@ class Client extends events_1.EventEmitter {
     // Start the Proc
     startServer() {
         // _env['TSS_LOG'] = "-logToFile true -file ./server.log"
-        this.serverHandle = child_process_1.spawn(this.serverPath, [...this.serverOptions, `--locale`, utils_1.getLocale(process.env), `--disableAutomaticTypingAcquisition`], {
-            stdio: 'pipe',
-            cwd: this._cwd,
-            env: this._env,
-            detached: true,
-            shell: false
-        });
+        if (os_1.platform() === 'win32') {
+            this.serverHandle = child_process_1.spawn("cmd", ['/c', this.serverPath, ...this.serverOptions, `--locale`, utils_1.getLocale(process.env), `--disableAutomaticTypingAcquisition`], {
+                stdio: 'pipe',
+                cwd: this._cwd,
+                env: this._env,
+                // detached must be false for windows to avoid child window
+                // https://nodejs.org/api/child_process.html#child_process_options_detached
+                detached: false,
+                shell: false
+            });
+        }
+        else {
+            this.serverHandle = child_process_1.spawn(this.serverPath, [...this.serverOptions, `--locale`, utils_1.getLocale(process.env), `--disableAutomaticTypingAcquisition`], {
+                stdio: 'pipe',
+                cwd: this._cwd,
+                env: this._env,
+                detached: true,
+                shell: false
+            });
+        }
         this._rl = readline_1.createInterface({
             input: this.serverHandle.stdout,
             output: this.serverHandle.stdin,


### PR DESCRIPTION
This resolves issues on Windows related to platform specific behavior in the Node child_process.spawn method. I was having trouble getting any of the functions working on Windows since the switch to the Node client. I believe this may help with the Windows issues that @isczg was seeing in #161.

Thanks for your work on this project!