### PR TITLE
getLocale alternative for Windows

### DIFF
--- a/doc/nvim-typescript.txt
+++ b/doc/nvim-typescript.txt
@@ -230,6 +230,13 @@ Default: 'TS'
     Use this vs setting from deoplete.
 
 
+g:nvim_typescript#server_options           *g:nvim_typescript#server_options*
+Values: List
+Default: '[]'
+
+    Sets options for the typescript server. For example, on Windows,
+    locale can be set to French using ['--locale', 'fr'].
+
 
 ===============================================================================
 MAPPINGS                                                  *typescript-mappings*

--- a/doc/nvim-typescript.txt
+++ b/doc/nvim-typescript.txt
@@ -234,8 +234,8 @@ g:nvim_typescript#server_options           *g:nvim_typescript#server_options*
 Values: List
 Default: '[]'
 
-    Sets options for the typescript server. For example, on Windows, locale 
-    can be set to French using ['--locale', 'fr'].
+    Sets options for the typescript server. For example, locale can be set to 
+    French using ['--locale', 'fr'].
 
 
 ===============================================================================

--- a/doc/nvim-typescript.txt
+++ b/doc/nvim-typescript.txt
@@ -234,8 +234,8 @@ g:nvim_typescript#server_options           *g:nvim_typescript#server_options*
 Values: List
 Default: '[]'
 
-    Sets options for the typescript server. For example, on Windows,
-    locale can be set to French using ['--locale', 'fr'].
+    Sets options for the typescript server. For example, on Windows, locale 
+    can be set to French using ['--locale', 'fr'].
 
 
 ===============================================================================

--- a/rplugin/node/nvim_typescript/lib/client.js
+++ b/rplugin/node/nvim_typescript/lib/client.js
@@ -52,8 +52,6 @@ class Client extends events_1.EventEmitter {
         else {
             this.serverHandle = child_process_1.spawn(this.serverPath, [
                 ...this.serverOptions,
-                `--locale`,
-                utils_1.getLocale(process.env),
                 `--disableAutomaticTypingAcquisition`
             ], {
                 stdio: 'pipe',

--- a/rplugin/node/nvim_typescript/lib/client.js
+++ b/rplugin/node/nvim_typescript/lib/client.js
@@ -38,8 +38,6 @@ class Client extends events_1.EventEmitter {
                 '/c',
                 this.serverPath,
                 ...this.serverOptions,
-                `--locale`,
-                utils_1.getLocale(process.env),
                 `--disableAutomaticTypingAcquisition`
             ], {
                 stdio: 'pipe',

--- a/rplugin/node/nvim_typescript/lib/utils.js
+++ b/rplugin/node/nvim_typescript/lib/utils.js
@@ -88,11 +88,6 @@ function getAbbr(entry) {
         .map((e, idx) => '<`' + (idx) + ':' + e + '`>')
         .join(', ');
 }
-function getLocale(procEnv) {
-    const lang = procEnv.LC_ALL || procEnv.LC_MESSAGES || procEnv.LANG || procEnv.LANGUAGE;
-    return lang && lang.replace(/[.:].*/, '').replace(/[_:].*/, '');
-}
-exports.getLocale = getLocale;
 function getKind(nvim, kind) {
     return __awaiter(this, void 0, void 0, function* () {
         const icons = yield nvim.getVar('nvim_typescript#kind_symbols');

--- a/rplugin/node/nvim_typescript/src/client.ts
+++ b/rplugin/node/nvim_typescript/src/client.ts
@@ -7,7 +7,7 @@ import { createInterface } from 'readline';
 
 import protocol from 'typescript/lib/protocol';
 
-import { trim, getLocale } from './utils';
+import { trim } from './utils';
 
 export class Client extends EventEmitter {
   public serverHandle: ChildProcess = null;
@@ -62,8 +62,6 @@ export class Client extends EventEmitter {
         this.serverPath,
         [
           ...this.serverOptions,
-          `--locale`,
-          getLocale(process.env),
           `--disableAutomaticTypingAcquisition`
         ],
         {

--- a/rplugin/node/nvim_typescript/src/client.ts
+++ b/rplugin/node/nvim_typescript/src/client.ts
@@ -45,8 +45,6 @@ export class Client extends EventEmitter {
           '/c',
           this.serverPath,
           ...this.serverOptions,
-          `--locale`,
-          getLocale(process.env),
           `--disableAutomaticTypingAcquisition`
         ],
         {

--- a/rplugin/node/nvim_typescript/src/utils.ts
+++ b/rplugin/node/nvim_typescript/src/utils.ts
@@ -89,12 +89,6 @@ function getAbbr(entry: protocol.CompletionEntryDetails) {
     .join(', ');
 }
 
-export function getLocale(procEnv) {
-  const lang =
-    procEnv.LC_ALL || procEnv.LC_MESSAGES || procEnv.LANG || procEnv.LANGUAGE;
-  return lang && lang.replace(/[.:].*/, '').replace(/[_:].*/, '');
-}
-
 export async function getKind(nvim: any, kind: string): Promise<any> {
   const icons = await nvim.getVar('nvim_typescript#kind_symbols');
   if (kind in icons) return icons[kind];


### PR DESCRIPTION
The getLocale method doesn't return anything on Windows and ends up causing tsserver errors during deoplete completion. I've removed the getLocale call from the Windows server start logic and added documentation on how to set the locale in Windows via the server_options variable.