### PR TITLE
Add an option to disable diagnostics on TextChanged

### DIFF
--- a/doc/nvim-typescript.txt
+++ b/doc/nvim-typescript.txt
@@ -244,6 +244,13 @@ Default: 1
     If set to 1, the linting errors will be shown.
 
 
+g:nvim_typescript#diagnostics_on_change     *g:nvim_typescript#diagnostics_on_change*
+Values: 0 or 1
+Default: 1
+
+    If set to 1, the linter will run on TextChanged.
+
+
 ===============================================================================
 MAPPINGS                                                  *typescript-mappings*
 

--- a/plugin/nvim_typescript.vim
+++ b/plugin/nvim_typescript.vim
@@ -31,6 +31,8 @@ let g:nvim_typescript#debug_settings =
       \ get(g:, 'nvim_typescript#debug_settings', {'file': 'nvim-typescript-tsserver.log', 'level': 'normal'})
 let g:nvim_typescript#diagnostics_enable =
       \ get(g:, 'nvim_typescript#diagnostics_enable', 1)
+let g:nvim_typescript#diagnostics_on_change =
+      \ get(g:, 'nvim_typescript#diagnostics_on_change', 1)
 let g:nvim_typescript#server_options =
       \ get(g:, 'nvim_typescript#server_options', [])
 let g:nvim_typescript#expand_snippet =
@@ -130,9 +132,11 @@ augroup nvim-typescript "{{{
     endif
     if get(g:, 'nvim_typescript#diagnostics_enable', 1)
       autocmd BufEnter,Filetype javascript,javascriptreact TSGetDiagnostics
-      autocmd TextChanged *.js,*.jsx TSGetDiagnostics
       autocmd InsertLeave *.js,*.jsx TSGetDiagnostics
       autocmd CursorMoved *.js,*.jsx call TSEchoMessage()
+    endif
+    if get(g:, 'nvim_typescript#diagnostics_on_change', 1)
+      autocmd TextChanged *.js,*.jsx TSGetDiagnostics
     endif
   endif "}}}
 
@@ -150,9 +154,11 @@ augroup nvim-typescript "{{{
     endif
     if get(g:, 'nvim_typescript#diagnostics_enable', 1)
       autocmd BufEnter,Filetype vue TSGetDiagnostics
-      autocmd TextChanged *.vue  TSGetDiagnostics
       autocmd InsertLeave *.vue TSGetDiagnostics
       autocmd CursorMoved *.vue call TSEchoMessage()
+    endif
+    if get(g:, 'nvim_typescript#diagnostics_on_change', 1)
+      autocmd TextChanged *.vue  TSGetDiagnostics
     endif
   endif "}}}
 
@@ -171,9 +177,11 @@ augroup nvim-typescript "{{{
   endif ""}}}
   if get(g:, 'nvim_typescript#diagnostics_enable', 1) "{{{
     autocmd BufEnter,Filetype typescript,typescript.tsx TSGetDiagnostics
-    autocmd TextChanged *.ts,*.tsx TSGetDiagnostics
     autocmd InsertLeave *.ts,*.tsx TSGetDiagnostics
     autocmd CursorMoved *.ts,*.tsx call TSEchoMessage()
+  endif "}}}
+  if get(g:, 'nvim_typescript#diagnostics_on_change', 1) "{{{
+    autocmd TextChanged *.ts,*.tsx TSGetDiagnostics
   endif "}}}
 
   autocmd BufWritePost tsconfig.json TSReloadProject

--- a/plugin/nvim_typescript.vim
+++ b/plugin/nvim_typescript.vim
@@ -133,6 +133,9 @@ augroup nvim-typescript "{{{
     if get(g:, 'nvim_typescript#diagnostics_enable', 1)
       autocmd BufEnter,Filetype javascript,javascriptreact TSGetDiagnostics
       autocmd InsertLeave *.js,*.jsx TSGetDiagnostics
+      if (get(g:, 'nvim_typescript#diagnostics_on_change', 1) == 0)
+        autocmd BufWrite *.js,*.jsx TSGetDiagnostics
+      endif
       autocmd CursorMoved *.js,*.jsx call TSEchoMessage()
     endif
     if get(g:, 'nvim_typescript#diagnostics_on_change', 1)
@@ -155,6 +158,9 @@ augroup nvim-typescript "{{{
     if get(g:, 'nvim_typescript#diagnostics_enable', 1)
       autocmd BufEnter,Filetype vue TSGetDiagnostics
       autocmd InsertLeave *.vue TSGetDiagnostics
+      if (get(g:, 'nvim_typescript#diagnostics_on_change', 1) == 0)
+        autocmd BufWrite *.vue TSGetDiagnostics
+      endif
       autocmd CursorMoved *.vue call TSEchoMessage()
     endif
     if get(g:, 'nvim_typescript#diagnostics_on_change', 1)
@@ -178,6 +184,9 @@ augroup nvim-typescript "{{{
   if get(g:, 'nvim_typescript#diagnostics_enable', 1) "{{{
     autocmd BufEnter,Filetype typescript,typescript.tsx TSGetDiagnostics
     autocmd InsertLeave *.ts,*.tsx TSGetDiagnostics
+    if (get(g:, 'nvim_typescript#diagnostics_on_change', 1) == 0)
+      autocmd BufWrite *.ts,*.tsx TSGetDiagnostics
+    endif
     autocmd CursorMoved *.ts,*.tsx call TSEchoMessage()
   endif "}}}
   if get(g:, 'nvim_typescript#diagnostics_on_change', 1) "{{{


### PR DESCRIPTION
When running on my Chromebook, deleting a few characters or lines in normal mode can get laggy with the `TextChanged` diagnostics check. I separated that into a second variable, `g:nvim_typescript#diagnostics_on_change` that is enabled by default to maintain current functionality, but when disabled will disable the `TextChanged` event and add a `BufWrite` event for the diagnostics check.

I tested these changes on my Chromebook and it made editing TypeScript files in normal mode significantly less laggy/jerky.