### PR TITLE
getRefs populates quickfix instead of location list

### DIFF
--- a/doc/nvim-typescript.txt
+++ b/doc/nvim-typescript.txt
@@ -237,6 +237,14 @@ Default: '[]'
     Sets options for the typescript server. For example, locale can be set to
     French using ['--locale', 'fr'].
 
+g:nvim_typescript#refs_to_loc_list           *g:nvim_typescript#refs_to_loc_list*
+Values: 0 or 1
+Default: 0
+
+    By default, a call to :TSRefs sends the references list to the quick-fix
+    window. This makes it send the list to the location-list instead.
+
+
 g:nvim_typescript#diagnostics_enable     *g:nvim_typescript#diagnostics_enable*
 Values: 0 or 1
 Default: 1

--- a/plugin/nvim_typescript.vim
+++ b/plugin/nvim_typescript.vim
@@ -35,6 +35,8 @@ let g:nvim_typescript#server_options =
       \ get(g:, 'nvim_typescript#server_options', [])
 let g:nvim_typescript#expand_snippet =
       \ get(g:, 'nvim_typescript#expand_snippet', 0)
+let g:nvim_typescript#refs_to_loc_list =
+      \ get(g:, 'nvim_typescript#refs_to_loc_list', 0)
 let g:nvim_typescript#follow_dir_change =
       \ get(g:, 'nvim_typescript#follow_dir_change', 0)
 let s:kind_symbols = {

--- a/rplugin/node/nvim_typescript/lib/index.js
+++ b/rplugin/node/nvim_typescript/lib/index.js
@@ -250,7 +250,7 @@ let TSHost = class TSHost {
                 return;
             }
             const refList = symbolRefRes.refs;
-            const locationList = refList.map(ref => {
+            const list = refList.map(ref => {
                 return {
                     filename: ref.file,
                     lnum: ref.start.line,
@@ -258,7 +258,7 @@ let TSHost = class TSHost {
                     text: utils_1.trim(ref.lineText)
                 };
             });
-            utils_1.createLocList(this.nvim, locationList, 'References');
+            utils_1.createQuickFixList(this.nvim, list, 'References');
         });
     }
     tsEditconfig(self) {

--- a/rplugin/node/nvim_typescript/lib/index.js
+++ b/rplugin/node/nvim_typescript/lib/index.js
@@ -258,7 +258,12 @@ let TSHost = class TSHost {
                     text: utils_1.trim(ref.lineText)
                 };
             });
-            utils_1.createQuickFixList(this.nvim, list, 'References');
+            if (this.refsToLocList) {
+                utils_1.createLocList(this.nvim, list, 'References');
+            }
+            else {
+                utils_1.createQuickFixList(this.nvim, list, 'References');
+            }
         });
     }
     tsEditconfig(self) {
@@ -649,12 +654,13 @@ let TSHost = class TSHost {
             this.diagnosticHost.nvim = this.nvim;
             // Borrowed from https://github.com/mhartington/nvim-typescript/pull/143
             // Much cleaner, sorry I couldn't merge the PR!
-            const [maxCompletion, serverPath, serverOptions, defaultSigns, expandSnippet] = yield Promise.all([
+            const [maxCompletion, serverPath, serverOptions, defaultSigns, expandSnippet, refsToLocList] = yield Promise.all([
                 this.nvim.getVar('nvim_typescript#max_completion_detail'),
                 this.nvim.getVar('nvim_typescript#server_path'),
                 this.nvim.getVar('nvim_typescript#server_options'),
                 this.nvim.getVar('nvim_typescript#default_signs'),
                 this.nvim.getVar('nvim_typescript#expand_snippet'),
+                this.nvim.getVar('nvim_typescript#refs_to_loc_list'),
             ]);
             this.maxCompletion = parseFloat(maxCompletion);
             this.expandSnippet = expandSnippet;
@@ -662,6 +668,7 @@ let TSHost = class TSHost {
             this.client.serverOptions = serverOptions;
             yield this.diagnosticHost.defineSigns(defaultSigns);
             this.client.setTSConfigVersion();
+            this.refsToLocList = refsToLocList;
             // this.client.on('semanticDiag', res => {
             //   console.log('coming soon...');
             // });

--- a/rplugin/node/nvim_typescript/src/index.ts
+++ b/rplugin/node/nvim_typescript/src/index.ts
@@ -12,6 +12,7 @@ import {
   convertEntry,
   getKind,
   createLocList,
+  createQuickFixList,
   printEllipsis
 } from './utils';
 import { writeFileSync, statSync, appendFileSync } from 'fs';
@@ -279,7 +280,7 @@ export default class TSHost {
     }
 
     const refList = symbolRefRes.refs;
-    const locationList = refList.map(ref => {
+    const list  = refList.map(ref => {
       return {
         filename: ref.file,
         lnum: ref.start.line,
@@ -287,7 +288,7 @@ export default class TSHost {
         text: trim(ref.lineText)
       };
     });
-    createLocList(this.nvim, locationList, 'References');
+    createQuickFixList(this.nvim, list , 'References');
   }
 
   @Command('TSEditConfig')

--- a/rplugin/node/nvim_typescript/src/index.ts
+++ b/rplugin/node/nvim_typescript/src/index.ts
@@ -29,6 +29,7 @@ export default class TSHost {
   private client = TSServer;
   private diagnosticHost = DiagnosticHost;
   private maxCompletion: number;
+  private refsToLocList: boolean;
   private expandSnippet: boolean;
   constructor(nvim) {
     this.nvim = nvim;
@@ -288,7 +289,12 @@ export default class TSHost {
         text: trim(ref.lineText)
       };
     });
-    createQuickFixList(this.nvim, list , 'References');
+
+    if (this.refsToLocList) {
+      createLocList(this.nvim, list, 'References')
+    } else {
+      createQuickFixList(this.nvim, list, 'References');
+    }
   }
 
   @Command('TSEditConfig')
@@ -709,14 +715,15 @@ export default class TSHost {
       serverPath,
       serverOptions,
       defaultSigns,
-      expandSnippet
+      expandSnippet,
+      refsToLocList
     ] = await Promise.all([
       this.nvim.getVar('nvim_typescript#max_completion_detail'),
       this.nvim.getVar('nvim_typescript#server_path'),
       this.nvim.getVar('nvim_typescript#server_options'),
       this.nvim.getVar('nvim_typescript#default_signs'),
       this.nvim.getVar('nvim_typescript#expand_snippet'),
-
+      this.nvim.getVar('nvim_typescript#refs_to_loc_list'),
     ]);
     this.maxCompletion = parseFloat(maxCompletion as string);
     this.expandSnippet = (expandSnippet as boolean);
@@ -724,6 +731,7 @@ export default class TSHost {
     this.client.serverOptions = serverOptions as string[];
     await this.diagnosticHost.defineSigns(defaultSigns);
     this.client.setTSConfigVersion();
+    this.refsToLocList = (refsToLocList as boolean);
 
     // this.client.on('semanticDiag', res => {
     //   console.log('coming soon...');


### PR DESCRIPTION
since refs are likely to be in other files, navigating via quickfix list
makes more sense. Location list can be cleared by many things -
typecheck errors, for instance.