### PR TITLE
Use || instead of ** to avoid duplication of tags

### DIFF
--- a/doc/nvim-typescript.txt
+++ b/doc/nvim-typescript.txt
@@ -292,7 +292,7 @@ A: This plugin does not claim to be better than any other plugin, and is more
 Q: I want to disable automatic diagnostic checks from this plugin and trigger
    it on save or some other event.
 
-A: Use the *g:nvim_typescript#diagnostics_enable* setting to disable automatic
+A: Use the |g:nvim_typescript#diagnostics_enable| setting to disable automatic
    diagnostic checks and manually add the autocmd hooks in your rc file.
 
    >


### PR DESCRIPTION
Vim complains of duplication helptags.  This patch uses references instead of tags to avoid this.

> Vim(helptags):E154: Duplicate tag "g:nvim_typescript#diagnostics_enable" in file /path/to/doc/nvim-typescript.txt