### PR TITLE
install.sh: set the file location directory as working dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,4 @@
 #!/bin/sh
+
+cd "$(dirname "$0")"
 cd rplugin/node/nvim_typescript && npm install && npm run build


### PR DESCRIPTION
This fixes issues when executing the install.sh script while not
standing in the same directory as it.