### PR TITLE
Added init to constructor

### DIFF
--- a/rplugin/node/nvim_typescript/lib/client.js
+++ b/rplugin/node/nvim_typescript/lib/client.js
@@ -124,7 +124,7 @@ class Client extends events_1.EventEmitter {
         return this._makeTssRequest('definition', args);
     }
     getCompletions(args) {
-        return this._makeTssRequest('completions', args);
+        return this._makeTssRequest('completionInfo', args);
     }
     getCompletionDetails(args) {
         return this._makeTssRequest('completionEntryDetails', args);

--- a/rplugin/node/nvim_typescript/lib/utils.js
+++ b/rplugin/node/nvim_typescript/lib/utils.js
@@ -142,3 +142,18 @@ function printEllipsis(nvim, message) {
     });
 }
 exports.printEllipsis = printEllipsis;
+// reduceByPrefix takes a list of basic complettions and a prefix and eliminates things 
+// that don't match the prefix
+exports.reduceByPrefix = (prefix, c) => {
+    const re = new RegExp(prefix, "i");
+    return c.filter(v => re.test(v.name));
+};
+// for testing rename results to gurantee the object type
+exports.isRenameSuccess = (obj) => obj.canRename;
+// trigger char is for complete requests to the TSServer, there are special completions when the 
+// trigger character is ., ", /, etc..
+const chars = [".", '"', "'", "`", "/", "@", "<"];
+exports.triggerChar = (p) => {
+    const char = p[p.length - 1];
+    return chars.includes(char) ? char : undefined;
+};

--- a/rplugin/node/nvim_typescript/src/client.ts
+++ b/rplugin/node/nvim_typescript/src/client.ts
@@ -153,8 +153,8 @@ export class Client extends EventEmitter {
   }
   getCompletions(
     args: protocol.CompletionsRequestArgs
-  ): Promise<protocol.CompletionsResponse['body']> {
-    return this._makeTssRequest('completions', args);
+  ): Promise<protocol.CompletionInfoResponse['body']> {
+    return this._makeTssRequest('completionInfo', args);
   }
   getCompletionDetails(
     args: protocol.CompletionDetailsRequestArgs

--- a/rplugin/node/nvim_typescript/src/utils.ts
+++ b/rplugin/node/nvim_typescript/src/utils.ts
@@ -1,6 +1,7 @@
 import protocol from 'typescript/lib/protocol';
 import { Neovim } from 'neovim';
 import { Client } from './client';
+
 export function trim(s: string) {
   return (s || '').replace(/^\s+|\s+$/g, '');
 }
@@ -150,4 +151,22 @@ export async function printEllipsis(nvim: Neovim, message: string) {
     msg = msg.substring(0, columns - 20) + '...';
   }
   await nvim.outWrite(`nvim-ts: ${msg} \n`);
+}
+
+// reduceByPrefix takes a list of basic complettions and a prefix and eliminates things 
+// that don't match the prefix
+export const reduceByPrefix = (prefix: string, c: ReadonlyArray<protocol.CompletionEntry>) => {
+   const re = new RegExp(prefix, "i")
+   return c.filter(v => re.test(v.name))
+}
+
+// for testing rename results to gurantee the object type
+export const isRenameSuccess = (obj: protocol.RenameInfoSuccess | protocol.RenameInfoFailure): obj is protocol.RenameInfoSuccess => obj.canRename
+
+// trigger char is for complete requests to the TSServer, there are special completions when the 
+// trigger character is ., ", /, etc..
+const chars = [".", '"', "'", "`", "/", "@", "<"]
+export const triggerChar = (p: string): protocol.CompletionsTriggerCharacter | undefined => {
+  const char = p[p.length - 1];
+  return chars.includes(char) ? char as protocol.CompletionsTriggerCharacter : undefined
 }

--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -31,18 +31,21 @@ class Source(Base):
         m = re.search(r"\w*$", context["input"])
         return m.start() if m else -1
 
+    def reset_var(self):
+        self.vim.vars["nvim_typescript#completion_res"] = []
+    
     def gather_candidates(self, context):
         try:
             if context["is_async"]:
                 res = self.vim.vars["nvim_typescript#completion_res"]
                 if res:
                     context["is_async"] = False
-                    self.vim.vars["nvim_typescript#completion_res"] = []
+                    self.reset_var()
                     return res
             else:
                 context["is_async"] = True
                 [offset] = context["complete_position"] + 1,
-                self.vim.vars["nvim_typescript#completion_res"] = []
+                self.reset_var()
                 self.vim.funcs.TSDeoplete(context["complete_str"], offset)
             return []
         except:


### PR DESCRIPTION
This is a WIP fix for #207

The init needs to also be called in the constructor, or else the maxCompletions will be udefined in the TSDeoplete method.

TSDeoplete also  doesn't do anything with the completion length so that when it gets detailedCompletions, it just sends them all to the server. In my case this is sending 1000+ completions which jams up the server forever because it sends that request on every keystroke and it can never catch up.

I think we need to take that completion list and run a fuzzy finder on it that ranks the top n under the completion length and only sends that to the server. I was thinking http://fusejs.io/ would be a good fuzzy lib to do this?

What do you think 
