### PR TITLE
fail to install if no NPM installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 
 cd "$(dirname "$0")"
-cd rplugin/node/nvim_typescript && npm install && npm run build
+if which npm >/dev/null; then
+	cd rplugin/node/nvim_typescript && npm install && npm run build
+else
+	if which yarn >/dev/null; then
+		cd rplugin/node/nvim_typescript && yarn && yarn build
+	else
+		echo "You must have NPM or Yarn installed"
+	fi
+fi


### PR DESCRIPTION
If you have only YARN installed, it will fail to install and cause
`E117: Unknown function: TSCloseWindow` to happens.

probably related to https://github.com/mhartington/nvim-typescript/issues/230