### PR TITLE
add g:nvim_typescript#quiet_startup

### DIFF
--- a/doc/nvim-typescript.txt
+++ b/doc/nvim-typescript.txt
@@ -224,6 +224,12 @@ Default: 1
 
     If set to 1, the linting errors will be shown.
 
+g:nvim_typescript#quiet_startup     *g:nvim_typescript#quiet_startup*
+Values: 0 or 1
+Default: 0
+
+    If set to 1, the "starting server" and "server started" messages won't
+    be shown.
 
 ===============================================================================
 MAPPINGS                                                  *typescript-mappings*

--- a/plugin/nvim_typescript.vim
+++ b/plugin/nvim_typescript.vim
@@ -29,6 +29,8 @@ let g:nvim_typescript#debug_settings =
       \ get(g:, 'nvim_typescript#debug_settings', {'file': 'nvim-typescript-tsserver.log', 'level': 'normal'})
 let g:nvim_typescript#diagnostics_enable =
       \ get(g:, 'nvim_typescript#diagnostics_enable', 1)
+let g:nvim_typescript#quiet_startup =
+      \ get(g:, 'nvim_typescript#quiet_startup', 0)
 let g:nvim_typescript#server_options =
       \ get(g:, 'nvim_typescript#server_options', [])
 let g:nvim_typescript#expand_snippet =


### PR DESCRIPTION
Adds a variable that makes nvim-typescript not show the "Starting Server..." and "Server started" messages.

Fixes: https://github.com/mhartington/nvim-typescript/issues/234