### PR TITLE
update required nvim version to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ nvim language service plugin for typescript
 
 ## Installation
 
-First make sure you have Neovim 0.2.1 or higher.
+First make sure you have Neovim 0.4.0 or higher.
 This includes the node-host that is required for this plugin.
 
 You will need a global install of the neovim client as well.

--- a/autoload/health/nvim_typescript.vim
+++ b/autoload/health/nvim_typescript.vim
@@ -39,7 +39,7 @@ endfunction "}}}
 
 function! s:check_required_node_for_nvim_typescript() abort "{{{
   call health#report_start('Check for node bindings')
-  if has('nvim-0.2.1')
+  if has('nvim-0.4.0')
     call health#report_ok('node bindings found')
   else
     call health#report_error('node bindings were not found', [


### PR DESCRIPTION
Documents required version of neovim to be at least v0.4.0.
Simplifies debugging missing functionality using `:checkhealth`

Closes #245