### PR TITLE
feat() make suggestions (rather than errors) optional

### DIFF
--- a/doc/nvim-typescript.txt
+++ b/doc/nvim-typescript.txt
@@ -231,6 +231,15 @@ Default: 0
     If set to 1, the "starting server" and "server started" messages won't
     be shown.
 
+                                      	 *g:nvim_typescript#suggestions_enabled*
+g:nvim_typescript#suggestions_enabled
+Values: 0 or 1
+Default: 1
+
+    Enables display of suggestions as well as errors. If set to 1, you will
+    be shown hints even for typescript errors that have been disabled in your
+    tsconfig.json.
+
 ===============================================================================
 MAPPINGS                                                  *typescript-mappings*
 

--- a/plugin/nvim_typescript.vim
+++ b/plugin/nvim_typescript.vim
@@ -37,6 +37,8 @@ let g:nvim_typescript#expand_snippet =
       \ get(g:, 'nvim_typescript#expand_snippet', 0)
 let g:nvim_typescript#follow_dir_change =
       \ get(g:, 'nvim_typescript#follow_dir_change', 0)
+let g:nvim_typescript#suggestions_enabled =
+      \ get(g:, 'nvim_typescript#suggestions_enabled', 0)
 let s:kind_symbols = {
     \ 'keyword': 'keyword',
     \ 'class': 'class',

--- a/rplugin/node/nvim_typescript/src/diagnostic.ts
+++ b/rplugin/node/nvim_typescript/src/diagnostic.ts
@@ -42,7 +42,15 @@ class DiagnosticProvider {
 
     // Normalize signs
     const normSigns = this.normalizeSigns(incomingSigns);
-    current.signs = normSigns;
+
+    // Strip out suggetions if they are not enabled
+    const suggestionsEnabled = await this.nvim.getVar('nvim_typescript#suggestions_enabled');
+    if (suggestionsEnabled) {
+      current.signs = normSigns;
+    } else {
+      current.signs = normSigns.filter(sign => sign.category !== 'suggestion');
+    }
+
     // Set buffer var for airline
     await this.nvim.buffer.setVar('nvim_typescript_diagnostic_info', current.signs);
 


### PR DESCRIPTION
To avoid the confusion described in #253 and reduce noise for users who have intentionally disabled certain typescript rules.