### PR TITLE
Do not run diagnostics on wrong files (fixes #258)

### DIFF
--- a/plugin/nvim_typescript.vim
+++ b/plugin/nvim_typescript.vim
@@ -122,7 +122,7 @@ augroup nvim-typescript "{{{
   if get(g:, 'nvim_typescript#javascript_support', 1)
 
     autocmd BufEnter *.js,*.jsx  call nvim_typescript#DefaultKeyMap()
-    autocmd BufEnter *.js,*.jsx  call TSOnBufEnter()
+    autocmd BufEnter *.js,*.jsx  call TSOnBufEnter(expand('<afile>'))
     autocmd BufUnload *.js,*.jsx  call TSOnBufLeave(expand('%:p'))
     autocmd BufWritePost *.js,*.jsx call TSOnBufSave()
     " if get(g:, 'nvim_typescript#signature_complete', 1)
@@ -144,7 +144,7 @@ augroup nvim-typescript "{{{
   if get(g:, 'nvim_typescript#vue_support', 1)
 
     autocmd BufEnter *.vue  call nvim_typescript#DefaultKeyMap()
-    autocmd BufEnter *.vue  call TSOnBufEnter()
+    autocmd BufEnter *.vue  call TSOnBufEnter(expand('<afile>'))
     autocmd BufWritePost *.vue call TSOnBufSave()
     autocmd BufUnload *.vue  call TSOnBufLeave(expand('%:p'))
     " if get(g:, 'nvim_typescript#signature_complete', 1)
@@ -162,7 +162,7 @@ augroup nvim-typescript "{{{
 
   " Core {{{
   autocmd BufEnter *.ts,*.tsx  call nvim_typescript#DefaultKeyMap()
-  autocmd BufEnter *.ts,*.tsx  call TSOnBufEnter()
+  autocmd BufEnter *.ts,*.tsx  call TSOnBufEnter(expand('<afile>'))
   autocmd BufUnload *.ts,*.tsx  call TSOnBufLeave(expand('%:p'))
   autocmd BufWritePost *.ts,*.tsx call TSOnBufSave()
   " if get(g:, 'nvim_typescript#signature_complete', 1) "{{{
@@ -186,4 +186,3 @@ augroup nvim-typescript "{{{
   "}}}
 
 augroup end "}}}
-


### PR DESCRIPTION
Plugin shouldn't expect that current file will always point to the same
file that was triggered on BufEnter. E.g. NerdTree preview's function
opens buffer and returns back to NerdTree buffer.

I'm pretty sure I have experienced problem like this even without
NerdTree where I have ended up with diagnostics running on text file.

