### PR TITLE
Delete stray console.warn that was blowing up TSDef (fixes #269)

### DIFF
--- a/rplugin/node/nvim_typescript/src/index.ts
+++ b/rplugin/node/nvim_typescript/src/index.ts
@@ -82,7 +82,6 @@ export default class TSHost {
   @Command('TSDef')
   async getDef() {
     const definition = await this.getDefFunc();
-    console.warn(JSON.stringify(definition))
     if (definition) {
       const defFile = definition[0].file;
       const defLine = definition[0].start.line;


### PR DESCRIPTION
After poking around in `getDef`, it seemed like this was the root cause of #269 — not the compiler API change I'd mistakenly initially pointed to.

Deleting the `console.warn` and recompiling with `install.sh` seemed to fix `:TSDef` for me. Not sure why, but... `¯\_(ツ)_/¯`