### PR TITLE
TSRefs does not auto open quick fix list

### DIFF
--- a/rplugin/node/nvim_typescript/src/index.ts
+++ b/rplugin/node/nvim_typescript/src/index.ts
@@ -258,7 +258,7 @@ export default class TSHost {
       };
     });
     // Uses QuickFix list as refs can span multiple files. QFList is better.
-    createQuickFixList(this.nvim, locationList, 'References');
+    createQuickFixList(this.nvim, locationList, 'References', true);
   }
 
   @Command('TSEditConfig')


### PR DESCRIPTION
## Problems summary

Since the default value for `autoOpen` in `createQuickFixList(…, autoOpen = false)` has been changed to  `false`, `TSRefs` is doing nothing.

## Expected

Calling `TSRefs` shows quick fix list containing all references.

## Environment Information

macOS 10.15.3 terminal, tmux 2.9a, NVIM v0.4.3

## Minimal vim rc

```ts
call dein#begin(expand('~/.vim/dein'))
  call dein#add('Shougo/dein.vim')
  call dein#add('mhartington/nvim-typescript', {'build': './install.sh'}) 
call dein#end()

let g:nvim_typescript#quiet_startup = 1
```
## Reproduce ways from neovim starting

1. start neovim with typescript file
2. position cursor under function (e.g.) you want the references
3. call `:TSRefs`

If I've misconfigured something, please let me know.
