### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ directory.  And try to run `:UpdateRemotePlugins` if you haven't already.
 
 ## Limitation
 
-If no completion is happening, please be sure to have a Typescript syntax file in your RTP. Neovim does not include a default syntax for Typescript, so be sure to include one. A popular syntax file for Typescript is [yats.vim](https://github.com/HerringtonDarkholme/yats.vim). Running nvim-typescript with no syntax file could lead to unexpected behavior.
+If no completion is happening, please be sure to have a Typescript syntax file in your RTP. Older versions of Neovim do not include a default syntax for Typescript, so be sure to include one. A popular syntax file for Typescript is [yats.vim](https://github.com/HerringtonDarkholme/yats.vim). As of v0.4.3, Neovim includes a default Typescript syntax file that is based off yats. Running nvim-typescript with no syntax file could lead to unexpected behavior.
 
 ## Open Open Source, or how to make this everyone's code
 


### PR DESCRIPTION
Neovim as of 0.4.3 now includes a typescript syntax file by default located at $VIMRUNTIME/syntax/typescript.vim